### PR TITLE
Fix iteration of downloads map

### DIFF
--- a/sphinx_build_compatibility/extension.py
+++ b/sphinx_build_compatibility/extension.py
@@ -79,13 +79,7 @@ def manipulate_config(app, config):
             if version["slug"] != version_slug:
                 continue
 
-            for key, value in version["downloads"]:
-                downloads.append(
-                    (
-                        key,
-                        value,
-                    ),
-                )
+            downloads.extend(version["downloads"].items())
     except Exception:
         logger.warning(
             "An error ocurred when generating the list of downloads. Defaulting to an empty list.",


### PR DESCRIPTION
When I added this project to my project, Django-MySQL, [its build](https://app.readthedocs.org/projects/django-mysql/builds/28657916/) logged this warning:

```
WARNING: An error ocurred when generating the list of downloads. Defaulting to an empty list.
Traceback (most recent call last):
 File "/.../sphinx_build_compatibility/extension.py", line 82, in manipulate_config
   for key, value in version["downloads"]:
       ^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```

Because the project has `sphinx.fail_on_warning: true` in its `.readthedocs.yaml` file, the build failed.

I checked the API data and it looks like `downloads` is returned as a JSON object, which is a dict in Python, so to iterate its keys and values, `.items()` is needed. It’s also possible to simplify away the loop by instead using `list.extend()`.

I tested my project with this fixed version of the extension and it built successfully: [build](https://app.readthedocs.org/projects/django-mysql/builds/28658041/).